### PR TITLE
Red & Blue CSS Class Fix

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -261,11 +261,11 @@ html, body {
     vertical-align: middle;
     border-radius: 2px;
 }
-.red {
+#titlescreen .red, #winner .red, #playing .red, .red {
     background-color: #d60000;
     color: #000;
 }
-.blue {
+#titlescreen .blue, #winner .blue, #playing .blue, .blue {
     background-color: #0055d6;
     color: #fff;
 }


### PR DESCRIPTION
This fix will allow red or blue classes to continue to be dispersed as they are today, but gain a higher specificity.

There are many ways to fix this issue, but after reviewing your JS files for handling of the classes, as well as your HTML, it seems that this choice will allow for you to continue on, without incurring any additional development.

Since the styling of #win-dialog held a reference to a background color and color, the ID on an element will always supersede the specificity of any classes to that element (barring nested selectors). Seeing as how your three main containers are  titlescreen, winner, playing, references to these were added to the properties you specified for classes red/blue.

Hope that helps!